### PR TITLE
[FIX] Picker bounces back when dragging to last date or time

### DIFF
--- a/wheel-picker-compose/src/main/java/com/commandiron/wheel_picker_compose/core/DefaultWheelDatePicker.kt
+++ b/wheel-picker-compose/src/main/java/com/commandiron/wheel_picker_compose/core/DefaultWheelDatePicker.kt
@@ -79,7 +79,9 @@ internal fun DefaultWheelDatePicker(
                 startIndex = dayOfMonths.find { it.value== startDate.dayOfMonth }?.index ?: 0,
                 onScrollFinished = { snappedIndex ->
 
-                    val newDayOfMonth = dayOfMonths.find { it.index == snappedIndex }?.value
+                    val newDayOfMonth =
+                        if (snappedIndex >= dayOfMonths.size) dayOfMonths.last().value
+                        else dayOfMonths.find { it.index == snappedIndex }?.value
 
                     newDayOfMonth?.let {
                         val newDate = snappedDate.withDayOfMonth(newDayOfMonth)
@@ -119,7 +121,8 @@ internal fun DefaultWheelDatePicker(
                 startIndex = months.find { it.value== startDate.monthValue }?.index ?: 0,
                 onScrollFinished = { snappedIndex ->
 
-                    val newMonth = months.find { it.index == snappedIndex }?.value
+                    val newMonth = if (snappedIndex >= months.size) months.last().value
+                    else months.find { it.index == snappedIndex }?.value
 
                     newMonth?.let {
 
@@ -164,7 +167,8 @@ internal fun DefaultWheelDatePicker(
                     startIndex = years.find { it.value == startDate.year }?.index ?:0,
                     onScrollFinished = { snappedIndex ->
 
-                        val newYear = years.find { it.index == snappedIndex }?.value
+                        val newYear = if (snappedIndex >= years.size) years.last().value
+                        else years.find { it.index == snappedIndex }?.value
 
                         newYear?.let {
 

--- a/wheel-picker-compose/src/main/java/com/commandiron/wheel_picker_compose/core/DefaultWheelTimePicker.kt
+++ b/wheel-picker-compose/src/main/java/com/commandiron/wheel_picker_compose/core/DefaultWheelTimePicker.kt
@@ -104,11 +104,15 @@ internal fun DefaultWheelTimePicker(
                 ),
                 onScrollFinished = { snappedIndex ->
 
-                    val newHour = if(timeFormat == TimeFormat.HOUR_24) {
-                        hours.find { it.index == snappedIndex }?.value
+                    val newHour = if (timeFormat == TimeFormat.HOUR_24) {
+                        if (snappedIndex >= hours.size) hours.last().value
+                        else
+                            hours.find { it.index == snappedIndex }?.value
                     } else {
                         amPmHourToHour24(
-                            amPmHours.find { it.index == snappedIndex }?.value ?: 0,
+                            if (snappedIndex >= amPmHours.size) amPmHours.last().value
+                            else
+                                amPmHours.find { it.index == snappedIndex }?.value ?: 0,
                             snappedTime.minute,
                             snappedAmPm.value
                         )
@@ -162,10 +166,12 @@ internal fun DefaultWheelTimePicker(
                 ),
                 onScrollFinished = { snappedIndex ->
 
-                    val newMinute = minutes.find { it.index == snappedIndex }?.value
+                    val newMinute = if (snappedIndex >= minutes.size) minutes.last().value
+                    else minutes.find { it.index == snappedIndex }?.value
 
-                    val newHour = if(timeFormat == TimeFormat.HOUR_24) {
-                        hours.find { it.value == snappedTime.hour }?.value
+                    val newHour = if (timeFormat == TimeFormat.HOUR_24) {
+                        if (snappedIndex >= hours.size) hours.last().value
+                        else hours.find { it.value == snappedTime.hour }?.value
                     } else {
                         amPmHourToHour24(
                             amPmHours.find { it.value == localTimeToAmPmHour(snappedTime) }?.value ?: 0,


### PR DESCRIPTION
Picker bounces back when dragging to last date or time because index is more than the size of the list